### PR TITLE
Reworked action with linters

### DIFF
--- a/.github/workflows/licheervnano-host-linux-amd64.yml
+++ b/.github/workflows/licheervnano-host-linux-amd64.yml
@@ -70,7 +70,7 @@ jobs:
             libatomic1-riscv64-cross \
             libc6-dbg-riscv64-cross \
             libc6-dev-riscv64-cross \
-            libconfuse-dev
+            libconfuse-dev \
             libegl1-mesa \
             liblz4-tool \
             libncurses-dev \

--- a/.github/workflows/licheervnano-host-linux-amd64.yml
+++ b/.github/workflows/licheervnano-host-linux-amd64.yml
@@ -1,15 +1,14 @@
+---
 name: licheervnano-host-linux-amd64-cvi-mmf-sdk-ci
-
 on:
   workflow_dispatch:
-
+env:
+  CVI_MMF_SDK: "cvi_mmf_sdk"
 jobs:
   mksys:
     strategy:
       fail-fast: false
-
     runs-on: ubuntu-22.04
-
     steps:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -17,92 +16,158 @@ jobs:
           max-size: "20G"
           create-symlink: true
           key: ${{matrix.os }}-${{ matrix.type }}
-
       - name: Create Timestamp
         run: |
-              echo "BUILD_ID=$(date +%Y%m%d_%H%M%S)" >> $GITHUB_ENV
-              echo "BUILD_DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
-
+          echo "BUILD_ID=$(date +%Y%m%d_%H%M%S)" >> "$GITHUB_ENV"
+          echo "BUILD_DATE=$(date +%Y%m%d)" >> "$GITHUB_ENV"
       - name: Install Software
         run: |
-              sudo apt update && \
-              sudo apt install -y build-essential autoconf automake autotools-dev ninja-build make help2man \
-                                  libncurses-dev gawk flex bison openssl libssl-dev tree wget curl cmake ccache \
-                                  libtool-bin bc bzr ca-certificates cmake cpio cvs file git locales mercurial \
-                                  openssh-server python3 python3-flake8 python3-magic python3-nose2 python3-pexpect \
-                                  python3-pytest rsync shellcheck subversion unzip pkg-config libssl-dev slib \
-                                  squashfs-tools android-sdk-libsparse-utils rsync jq cmake python3-distutils \
-                                  tclsh scons parallel ssh-client tree python3-dev python3-pip device-tree-compiler \
-                                  libssl-dev ssh cpio squashfs-tools fakeroot libncurses5-dev flex bison mmdebstrap \
-                                  android-libext4-utils bdebstrap proot fakeroot fakechroot python3 python3-flake8 \
-                                  python3-nose2 python3-pexpect subversion unzip ccache picolibc-riscv64-unknown-elf\
-                                  crossbuild-essential-riscv64 binutils-riscv64-unknown-elf\
-                                  cpp-riscv64-linux-gnu g++-riscv64-linux-gnu gcc-riscv64-linux-gnu\
-                                  libc6-dbg-riscv64-cross libatomic1-riscv64-cross libasan8-riscv64-cross\
-                                  libc6-dev-riscv64-cross gcc-riscv64-unknown-elf gawk diffstat texinfo\
-                                  chrpath socat python3-pip python3-pexpect xz-utils debianutils \
-                                  iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
-                                  python3-subunit mesa-common-dev zstd liblz4-tool libacl1 parted erofs-utils \
-                                  genext2fs mtools fatcat ckermit neovim cscope asciinema libconfuse-dev
-
-
+          sudo apt update && \
+          sudo apt install -y \
+            android-libext4-utils \
+            android-sdk-libsparse-utils \
+            asciinema \
+            autoconf \
+            automake \
+            autotools-dev \
+            bc \
+            bdebstrap \
+            binutils-riscv64-unknown-elf \
+            bison \
+            build-essential \
+            bzr \
+            ca-certificates \
+            ccache \
+            chrpath \
+            ckermit \
+            cmake \
+            cpio \
+            cpp-riscv64-linux-gnu \
+            crossbuild-essential-riscv64 \
+            cscope \
+            curl \
+            cvs \
+            debianutils \
+            device-tree-compiler \
+            diffstat \
+            erofs-utils \
+            fakechroot \
+            fakeroot \
+            fatcat \
+            file \
+            flex \
+            g++-riscv64-linux-gnu \
+            gawk \
+            gcc-riscv64-linux-gnu \
+            gcc-riscv64-unknown-elf \
+            genext2fs \
+            git \
+            help2man \
+            iputils-ping \
+            jq \
+            libacl1 \
+            libasan8-riscv64-cross \
+            libatomic1-riscv64-cross \
+            libc6-dbg-riscv64-cross \
+            libc6-dev-riscv64-cross \
+            libconfuse-dev
+            libegl1-mesa \
+            liblz4-tool \
+            libncurses-dev \
+            libncurses5-dev \
+            libsdl1.2-dev \
+            libssl-dev \
+            libtool-bin \
+            locales \
+            make \
+            mercurial \
+            mesa-common-dev \
+            mmdebstrap \
+            mtools \
+            neovim \
+            ninja-build \
+            openssh-server \
+            openssl \
+            parallel \
+            parted \
+            picolibc-riscv64-unknown-elf \
+            pkg-config \
+            proot \
+            python3 \
+            python3-dev \
+            python3-distutils \
+            python3-flake8 \
+            python3-git \
+            python3-jinja2 \
+            python3-magic \
+            python3-nose2 \
+            python3-pexpect \
+            python3-pip \
+            python3-pytest \
+            python3-subunit \
+            rsync \
+            scons \
+            shellcheck \
+            slib \
+            socat \
+            squashfs-tools \
+            ssh \
+            ssh-client \
+            subversion \
+            tclsh \
+            texinfo \
+            tree \
+            unzip \
+            wget \
+            xz-utils \
+            zstd
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-            path: 'cvi_mmf_sdk'  # TODO: make this name a global variable
-            ref: 'main'
-
+          path: '${{ env.CVI_MMF_SDK }}'
+          ref: 'main'
+          persist-credentials: false
       - name: Download Toolchain
         run: |
-              export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-              pushd cvi_mmf_sdk
-                wget https://sophon-file.sophon.cn/sophon-prod-s3/drive/23/03/07/16/host-tools.tar.gz
-                tar xf host-tools.tar.gz
-              popd
-
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          pushd "${CVI_MMF_SDK}" || exit
+            wget https://sophon-file.sophon.cn/sophon-prod-s3/drive/23/03/07/16/host-tools.tar.gz
+            tar xf host-tools.tar.gz
+          popd || exit
+        env:
+          CVI_MMF_SDK: ${{ env.CVI_MMF_SDK }}
       - name: Make System
         run: |
-              pushd cvi_mmf_sdk
-                source build/cvisetup.sh
-                defconfig sg2002_licheervnano_sd
-                build_all
-                # build other variant
-                cp build/boards/sg200x/sg2002_licheervnano_sd/sg2002_licheervnano_sd_defconfig bak.config
+          pushd "${CVI_MMF_SDK}" || exit
+            source "build/cvisetup.sh"
+            defconfig sg2002_licheervnano_sd
+            build_all
 
-                # 2.8inch
-                cat bak.config | sed -e 's/CONFIG_MIPI_PANEL_ZCT2133V1/CONFIG_MIPI_PANEL_ST7701_HD228001C31/g' > build/boards/sg200x/sg2002_licheervnano_sd/sg2002_licheervnano_sd_defconfig
-                defconfig sg2002_licheervnano_sd
-                clean_uboot
-                clean_opensbi
-                clean_fsbl
-                build_fsbl
-                cp -v cvi_mmf_sdk/install/soc_sg2002_licheervnano_sd/fip.bin cvi_mmf_sdk/install/soc_sg2002_licheervnano_sd/hd228001c31.bin
+            # Build other variants.
+            BOARD_DEFCONFIG="build/boards/sg200x/sg2002_licheervnano_sd/sg2002_licheervnano_sd_defconfig"
+            cp "${BOARD_DEFCONFIG}" bak.config
 
-                # 3inch
-                cat bak.config | sed -e 's/CONFIG_MIPI_PANEL_ZCT2133V1/CONFIG_MIPI_PANEL_ST7701_D300FPC9307A/g' > build/boards/sg200x/sg2002_licheervnano_sd/sg2002_licheervnano_sd_defconfig
-                defconfig sg2002_licheervnano_sd
-                clean_uboot
-                clean_opensbi
-                clean_fsbl
-                build_fsbl
-                cp -v cvi_mmf_sdk/install/soc_sg2002_licheervnano_sd/fip.bin cvi_mmf_sdk/install/soc_sg2002_licheervnano_sd/d300fpc9307a.bin
+            #            2.8inch,      3inch,         5inch
+            for panel in "hd228001c31" "d300fpc9307a" "dxq5d0019b480854"; do
+              sed -e "s/CONFIG_MIPI_PANEL_ZCT2133V1/CONFIG_MIPI_PANEL_ST7701_${panel^^}/g" "bak.config" \
+                > "${BOARD_DEFCONFIG}"
+              defconfig sg2002_licheervnano_sd
+              clean_uboot
+              clean_opensbi
+              clean_fsbl
+              build_fsbl
+              cp -v "${CVI_MMF_SDK}/install/soc_sg2002_licheervnano_sd/fip.bin" \
+                "${CVI_MMF_SDK}/install/soc_sg2002_licheervnano_sd/${panel^^}.bin"
+            done
 
-                # 5inch
-                cat bak.config | sed -e 's/CONFIG_MIPI_PANEL_ZCT2133V1/CONFIG_MIPI_PANEL_ST7701_DXQ5D0019B480854/g' > build/boards/sg200x/sg2002_licheervnano_sd/sg2002_licheervnano_sd_defconfig
-                defconfig sg2002_licheervnano_sd
-                clean_uboot
-                clean_opensbi
-                clean_fsbl
-                build_fsbl
-                cp -v cvi_mmf_sdk/install/soc_sg2002_licheervnano_sd/fip.bin cvi_mmf_sdk/install/soc_sg2002_licheervnano_sd/dxq5d0019b480854.bin
-
-              popd
-
+          popd || exit
+        env:
+          CVI_MMF_SDK: ${{ env.CVI_MMF_SDK }}
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v3
         with:
           retention-days: 30
           name: licheervnano-cvi-mmf-sdk-output-${{ env.BUILD_ID }}
           path: |
-                  cvi_mmf_sdk/install/soc_sg2002_licheervnano_sd/images/*
-                  cvi_mmf_sdk/install/soc_sg2002_licheervnano_sd/*.bin
+            ${{ env.CVI_MMF_SDK }}/install/soc_sg2002_licheervnano_sd/images/*
+            ${{ env.CVI_MMF_SDK }}/install/soc_sg2002_licheervnano_sd/*.bin


### PR DESCRIPTION
# Linters

Improve quality, consistency and readbility with the following [pre-commit hooks](https://pre-commit.com/):

- action-lint
- shellcheck
- shfmt
- zizmor

# Findings

```
Lint GitHub Actions workflow files.......................................Failed
- hook id: actionlint
- exit code: 1

.github/workflows/licheervnano-host-linux-amd64.yml:16:19: property "os" is not defined in object type {} [expression]
   |
16 |           key: ${{matrix.os }}-${{ matrix.type }}
   |                   ^~~~~~~~~
.github/workflows/licheervnano-host-linux-amd64.yml:18:9: shellcheck reported issue in this script: SC2086:info:1:43: Double quote to prevent globbing and word splitting [shellcheck]
   |
18 |         run: |
   |         ^~~~
.github/workflows/licheervnano-host-linux-amd64.yml:18:9: shellcheck reported issue in this script: SC2086:info:2:38: Double quote to prevent globbing and word splitting [shellcheck]
   |
18 |         run: |
   |         ^~~~
.github/workflows/licheervnano-host-linux-amd64.yml:55:9: shellcheck reported issue in this script: SC2002:style:9:7: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead [shellcheck]
   |
55 |         run: |
   |         ^~~~
.github/workflows/licheervnano-host-linux-amd64.yml:55:9: shellcheck reported issue in this script: SC2002:style:18:7: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead [shellcheck]
   |
55 |         run: |
   |         ^~~~
.github/workflows/licheervnano-host-linux-amd64.yml:55:9: shellcheck reported issue in this script: SC2002:style:27:7: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead [shellcheck]
   |
55 |         run: |
   |         ^~~~

zizmor...................................................................Failed
- hook id: zizmor
- exit code: 13
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/licheervnano-host-linux-amd64.yml:42:9
   |
42 |         - name: Checkout Repo
   |  _________-
43 | |         uses: actions/checkout@v3
44 | |         with:
45 | |           path: 'cvi_mmf_sdk' # TODO: make this name a global variable
46 | |           ref: 'main'
   | |_____________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

1 finding: 0 unknown, 0 informational, 0 low, 1 medium, 0 high
```

# Worklog

- property "os" is not defined -- ignored
- SC2086 -- resolved
- SC2002 -- resolved
- does not set persist-credentials: false -- resolved
- TODO: make this name a global variable -- resolved, creates more linter warnings, also resolved
- list of packages flattened and de-duplicated (flex and other packages were included twice), some of the packages look like meta packages to me and should be checked, Consider using `--no-install-recommends` option to only install the required packages.
- variant configuration is processed 3 times and has been turned into a loop by leveraging bash string manipulation https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
  Example to proof that it works as intended:
```bash
$ panel="hd228001c31"
$ sed -e "s/CONFIG_MIPI_PANEL_ZCT2133V1/CONFIG_MIPI_PANEL_ST7701_${panel^^}/g" <<< "CONFIG_MIPI_PANEL_ZCT2133V1__123"
CONFIG_MIPI_PANEL_ST7701_HD228001C31__123
```