### PR TITLE
Circular building 11 fip variants

### DIFF
--- a/build-licheervnano.sh
+++ b/build-licheervnano.sh
@@ -11,6 +11,7 @@ qt5=y
 tailscale=n
 tpudemo=c
 tpusdk=y
+panelvariants=n
 while [ "$#" -gt 0 ]; do
 	case "$1" in
 	--board=*|--board-link=*)
@@ -78,6 +79,10 @@ while [ "$#" -gt 0 ]; do
 	--no-tpu-sdk|--no-tpusdk)
 		shift
 		tpusdk=n
+		;;
+	--panel-variants)
+		shift
+		panelvariants=y
 		;;
 	*)
 		break
@@ -213,36 +218,38 @@ if ! grep -q -E 'CONFIG_MIPI_PANEL_ZCT2133V1=y' bak.config ; then
 fi
 cp -v install/soc_${SG_BOARD_LINK}/fip.bin install/soc_${SG_BOARD_LINK}/zct2133v1.bin
 
-# 7inch
-build_fip_variant MIPI_PANEL_MTD700920B
-# 2.8inch
-build_fip_variant MIPI_PANEL_ST7701_HD228001C31
-# 2.8inch alt0
-build_fip_variant MIPI_PANEL_ST7701_HD228001C31_ALT0
-# 2.28 inch lhcm
-build_fip_variant MIPI_PANEL_ST7701_LHCM228TS003A
-# 3inch
-build_fip_variant MIPI_PANEL_ST7701_D300FPC9307A
-# 3.1inch
-build_fip_variant MIPI_PANEL_ST7701_D310T9362V1
-# 5inch
-build_fip_variant MIPI_PANEL_ST7701_DXQ5D0019B480854
-# 5inch new
-build_fip_variant MIPI_PANEL_ST7701_DXQ5D0019_V0
-# 2.4inch
-build_fip_variant MIPI_PANEL_D240SI31
-# dsi to hdmi
-build_fip_variant MIPI_PANEL_LT9611_1024X768_60HZ
-# dsi to hdmi
-build_fip_variant MIPI_PANEL_LT9611_1280X720_60HZ
+if [ $panelvariants = y ]; then
+	# 7inch
+	build_fip_variant MIPI_PANEL_MTD700920B
+	# 2.8inch
+	build_fip_variant MIPI_PANEL_ST7701_HD228001C31
+	# 2.8inch alt0
+	build_fip_variant MIPI_PANEL_ST7701_HD228001C31_ALT0
+	# 2.28 inch lhcm
+	build_fip_variant MIPI_PANEL_ST7701_LHCM228TS003A
+	# 3inch
+	build_fip_variant MIPI_PANEL_ST7701_D300FPC9307A
+	# 3.1inch
+	build_fip_variant MIPI_PANEL_ST7701_D310T9362V1
+	# 5inch
+	build_fip_variant MIPI_PANEL_ST7701_DXQ5D0019B480854
+	# 5inch new
+	build_fip_variant MIPI_PANEL_ST7701_DXQ5D0019_V0
+	# 2.4inch
+	build_fip_variant MIPI_PANEL_D240SI31
+	# dsi to hdmi
+	build_fip_variant MIPI_PANEL_LT9611_1024X768_60HZ
+	# dsi to hdmi
+	build_fip_variant MIPI_PANEL_LT9611_1280X720_60HZ
 
-if echo ${SG_BOARD_LINK} | grep -q milkv_duos ; then
-  # 8inch
-  build_fip_variant MIPI_PANEL_MILKV_8HD
-  # 8inch 2lane
-  build_fip_variant MIPI_PANEL_MILKV_8HD_2LANE
-  # 4inch
-  build_fip_variant MIPI_PANEL_MILKV_ST7796S
+	if echo ${SG_BOARD_LINK} | grep -q milkv_duos ; then
+	# 8inch
+	build_fip_variant MIPI_PANEL_MILKV_8HD
+	# 8inch 2lane
+	build_fip_variant MIPI_PANEL_MILKV_8HD_2LANE
+	# 4inch
+	build_fip_variant MIPI_PANEL_MILKV_ST7796S
+	fi
 fi
 
 mv bak.config build/boards/${SG_BOARD_FAMILY}/${SG_BOARD_LINK}/${SG_BOARD_LINK}_defconfig


### PR DESCRIPTION
Currently if I call `build-licheervnano.sh` script it will build fsbl and uboot and than will call `build_fip_variant` for 11 panels and each call cleans current fsbl and uboot build artifacts and rebuild them from scratch to support specified panel. I think it is not necessary for general users to build image with such wide support of panels. So, currently I just wrap build_fip_variant calls into cli argument `panel-variants` that default is n, so no rebuilding happens. But maybe `panel-variants` need to have not just binary value, maybe it need to strore list of panels for build?